### PR TITLE
allow uppercase and : serverity in hub model

### DIFF
--- a/python/twistedActor/hub.py
+++ b/python/twistedActor/hub.py
@@ -66,7 +66,7 @@ class HubConnection(device.TCPDevice):
             return
 
         matched = re.match(r'^(?P<commanderID>.+) (?P<cmdID>[0-9]+) '
-                           r'(?P<userID>.+) (?P<severity>[a-zA-Z,:]) '
+                           r'(?P<userID>.+) (?P<severity>[a-z,A-Z,:]) '
                            r'(?P<cmd>.+)$', reply_str)
 
         if matched:

--- a/python/twistedActor/hub.py
+++ b/python/twistedActor/hub.py
@@ -66,7 +66,7 @@ class HubConnection(device.TCPDevice):
             return
 
         matched = re.match(r'^(?P<commanderID>.+) (?P<cmdID>[0-9]+) '
-                           r'(?P<userID>.+) (?P<severity>[a-z]) '
+                           r'(?P<userID>.+) (?P<severity>[a-zA-Z,:]) '
                            r'(?P<cmd>.+)$', reply_str)
 
         if matched:


### PR DESCRIPTION
It looks like not all commands use lower case letters or even letters! This 6 character change allows the hub model to interpret more (nearly all) messages passed through the hub, including an import apogee status message.